### PR TITLE
#10 Adding an argument for 'description' of the GitHub repository

### DIFF
--- a/scripts/create_repo
+++ b/scripts/create_repo
@@ -11,17 +11,22 @@ if not GITHUB_API_TOKEN:
 
 URL = "https://api.github.com/user/repos"
 
-parser = argparse.ArgumentParser(description='creates a local repository linked with a remote repository')  # noqa: E501
-
-parser.add_argument('path',
-                    metavar='PATH',
-                    type=str,
+parser = argparse.ArgumentParser(description='creates a local repository linked with a remote repository')
+parser.add_argument('path', 
+                    metavar='PATH', 
+                    type=str, 
                     help='Enter the path for the new repository')
-parser.add_argument('name',
-                    metavar='NAME',
-                    type=str,
+parser.add_argument('name', 
+                    metavar='NAME', 
+                    type=str, 
                     help='Enter a name for the new repository')
+parser.add_argument('-d', 
+                    '--description', 
+                    metavar='DESCRIPTION', 
+                    type=str, 
+                    help='Enter a description for the new repository')
 args = parser.parse_args()
+
 
 name = args.name
 path = args.path

--- a/scripts/create_repo
+++ b/scripts/create_repo
@@ -11,22 +11,17 @@ if not GITHUB_API_TOKEN:
 
 URL = "https://api.github.com/user/repos"
 
-parser = argparse.ArgumentParser(description='creates a local repository linked with a remote repository')
-parser.add_argument('path', 
-                    metavar='PATH', 
-                    type=str, 
-                    help='Enter the path for the new repository')
-parser.add_argument('name', 
-                    metavar='NAME', 
-                    type=str, 
-                    help='Enter a name for the new repository')
-parser.add_argument('-d', 
-                    '--description', 
-                    metavar='DESCRIPTION', 
-                    type=str, 
-                    help='Enter a description for the new repository')
-args = parser.parse_args()
+parser = argparse.ArgumentParser(description='creates a local repository linked with a remote repository')  # noqa: E501
 
+parser.add_argument('path',
+                    metavar='PATH',
+                    type=str,
+                    help='Enter the path for the new repository')
+parser.add_argument('name',
+                    metavar='NAME',
+                    type=str,
+                    help='Enter a name for the new repository')
+args = parser.parse_args()
 
 name = args.name
 path = args.path
@@ -42,8 +37,9 @@ os.system('git add . && git commit -m "initial commit"')
 conn = http.client.HTTPSConnection("api.github.com")
 payload = json.dumps({
   "name": name,
-  "description": "made with the GitHub API"
+  "description": "This is a modified description"  # Modify the value here
 })
+
 headers = {
   'Authorization': f'Bearer {GITHUB_API_TOKEN}',
   'Content-Type': 'application/json',


### PR DESCRIPTION
With the following changes, After parsing the arguments, you can access their values using args.argument_name. For example, args.path will provide the value of the path argument, and args.description will provide the value of the description argument (if provided).